### PR TITLE
Implement IBuildDetails.ByBuildId

### DIFF
--- a/src/TeamCitySharp/ActionTypes/BuildDetails.cs
+++ b/src/TeamCitySharp/ActionTypes/BuildDetails.cs
@@ -21,5 +21,12 @@ namespace TeamCitySharp.ActionTypes
 
             return buildWrapper.Build == null ? null : buildWrapper.Build.FirstOrDefault();
         }
+
+        public Build ByBuildId(string buildId)
+        {
+            var build = _caller.GetFormat<Build>("/app/rest/builds/{0}", buildId);
+
+            return build;
+        }
     }
 }

--- a/src/TeamCitySharp/ActionTypes/BuildDetails.cs
+++ b/src/TeamCitySharp/ActionTypes/BuildDetails.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using System.Collections.Generic;
+using TeamCitySharp.Connection;
+using TeamCitySharp.DomainEntities;
+using TeamCitySharp.Locators;
+
+namespace TeamCitySharp.ActionTypes
+{
+    internal class BuildDetails : IBuildDetails
+    {
+        private readonly TeamCityCaller _caller;
+
+        internal BuildDetails(TeamCityCaller caller)
+        {
+            _caller = caller;
+        }
+
+        public Build ByBuildLocator(BuildLocator locator)
+        {
+            var buildWrapper = _caller.GetFormat<BuildWrapper>("/app/rest/builds/{0}", locator);
+
+            return buildWrapper.Build == null ? null : buildWrapper.Build.FirstOrDefault();
+        }
+    }
+}

--- a/src/TeamCitySharp/ActionTypes/Changes.cs
+++ b/src/TeamCitySharp/ActionTypes/Changes.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using TeamCitySharp.Connection;
 using TeamCitySharp.DomainEntities;
+using TeamCitySharp.Locators;
 
 namespace TeamCitySharp.ActionTypes
 {
@@ -42,5 +43,18 @@ namespace TeamCitySharp.ActionTypes
             return changes.FirstOrDefault();
         }
 
+        public List<Change> ByBuildLocator(BuildLocator buildLocator)
+        {
+            var changeWrapper = _caller.GetFormat<ChangeWrapper>("/app/rest/changes?build={0}", buildLocator);
+
+            if (changeWrapper.Change == null)
+            {
+                return new List<Change>();
+            }
+
+            return changeWrapper.Change
+                                .Select(c => _caller.GetFormat<Change>("/app/rest/changes/id:{0}", c.Id))
+                                .ToList();
+        }
     }
 }

--- a/src/TeamCitySharp/ActionTypes/IBuildDetails.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuildDetails.cs
@@ -1,0 +1,12 @@
+using System.Linq;
+using System.Collections.Generic;
+using TeamCitySharp.DomainEntities;
+using TeamCitySharp.Locators;
+
+namespace TeamCitySharp.ActionTypes
+{
+    public interface IBuildDetails
+    {
+        Build ByBuildLocator(BuildLocator locator);
+    }
+}

--- a/src/TeamCitySharp/ActionTypes/IBuildDetails.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuildDetails.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-using System.Collections.Generic;
 using TeamCitySharp.DomainEntities;
 using TeamCitySharp.Locators;
 
@@ -8,5 +6,6 @@ namespace TeamCitySharp.ActionTypes
     public interface IBuildDetails
     {
         Build ByBuildLocator(BuildLocator locator);
+        Build ByBuildId(string buildId);
     }
 }

--- a/src/TeamCitySharp/ActionTypes/IChanges.cs
+++ b/src/TeamCitySharp/ActionTypes/IChanges.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using TeamCitySharp.DomainEntities;
+using TeamCitySharp.Locators;
 
 namespace TeamCitySharp.ActionTypes
 {
@@ -9,5 +10,6 @@ namespace TeamCitySharp.ActionTypes
         Change ByChangeId(string id);
         Change LastChangeDetailByBuildConfigId(string buildConfigId);
         List<Change> ByBuildConfigId(string buildConfigId);
+        List<Change> ByBuildLocator(BuildLocator buildLocator);
     }
 }

--- a/src/TeamCitySharp/DomainEntities/Build.cs
+++ b/src/TeamCitySharp/DomainEntities/Build.cs
@@ -22,6 +22,5 @@ namespace TeamCitySharp.DomainEntities
         {
             return Number;
         }
-        
     }
 }

--- a/src/TeamCitySharp/ITeamCityClient.cs
+++ b/src/TeamCitySharp/ITeamCityClient.cs
@@ -8,6 +8,7 @@ namespace TeamCitySharp
         bool Authenticate();
 
         IBuilds Builds { get; }
+        IBuildDetails BuildDetails { get; }
         IBuildConfigs BuildConfigs { get; }
         IProjects Projects { get; }
         IServerInformation ServerInformation { get; }

--- a/src/TeamCitySharp/TeamCityClient.cs
+++ b/src/TeamCitySharp/TeamCityClient.cs
@@ -7,6 +7,7 @@ namespace TeamCitySharp
     {
         private readonly TeamCityCaller _caller;
         private IBuilds _builds;
+        private IBuildDetails _buildDetails;
         private IProjects _projects;
         private IBuildConfigs _buildConfigs;
         private IServerInformation _serverInformation;
@@ -34,6 +35,11 @@ namespace TeamCitySharp
         public IBuilds Builds
         {
             get { return _builds ?? (_builds = new Builds(_caller)); }
+        }
+
+        public IBuildDetails BuildDetails
+        {
+            get { return _buildDetails ?? (_buildDetails = new BuildDetails(_caller)); }
         }
 
         public IBuildConfigs BuildConfigs

--- a/src/TeamCitySharp/TeamCitySharp.csproj
+++ b/src/TeamCitySharp/TeamCitySharp.csproj
@@ -52,11 +52,13 @@
     <Compile Include="ActionTypes\Agents.cs" />
     <Compile Include="ActionTypes\BuildArtifacts.cs" />
     <Compile Include="ActionTypes\BuildConfigs.cs" />
+    <Compile Include="ActionTypes\BuildDetails.cs" />
     <Compile Include="ActionTypes\Builds.cs" />
     <Compile Include="ActionTypes\Changes.cs" />
     <Compile Include="ActionTypes\IAgents.cs" />
     <Compile Include="ActionTypes\IBuildArtifacts.cs" />
     <Compile Include="ActionTypes\IBuildConfigs.cs" />
+    <Compile Include="ActionTypes\IBuildDetails.cs" />
     <Compile Include="ActionTypes\IBuilds.cs" />
     <Compile Include="ActionTypes\IChanges.cs" />
     <Compile Include="ActionTypes\IProjects.cs" />


### PR DESCRIPTION
The BuildLocator formats the query with "id:", which seems to not be supported by TeamCity.
